### PR TITLE
Account Creation Auto-renew

### DIFF
--- a/examples/create_account/main.go
+++ b/examples/create_account/main.go
@@ -45,6 +45,7 @@ func main() {
 	transaction, err := client.CreateAccount().
 		Key(public).
 		InitialBalance(0).
+		AutoRenew(hedera.Duration{Seconds:7890000}). //7890000 is the current default (~90 days)
 		Operator(operatorAccountID).
 		Node(nodeAccountID).
 		Memo("[test] hedera-sdk-go v2").

--- a/transaction_crypto_create.go
+++ b/transaction_crypto_create.go
@@ -33,3 +33,8 @@ func (tx TransactionCryptoCreate) Node(id AccountID) TransactionCryptoCreate {
 func (tx TransactionCryptoCreate) Memo(memo string) TransactionCryptoCreate {
 	return TransactionCryptoCreate{tx.transaction.Memo(memo)}
 }
+
+func (tx TransactionCryptoCreate) AutoRenew(period Duration) TransactionCryptoCreate {
+	C.hedera_transaction__crypto_create__set_auto_renew_period(tx.inner, cDuration(period))
+	return tx
+}


### PR DESCRIPTION
Hi,

Just noticed that the default SDK didn't include logic to set the Auto-Renew duration when creating accounts, so I've included the logic in transaction_crypto_create.go and updated the demo to reflect the change.


Cheers, Rhys.